### PR TITLE
改修

### DIFF
--- a/02_sheet-revival/main.bas
+++ b/02_sheet-revival/main.bas
@@ -92,7 +92,10 @@ Function writeFromExcelToText()
             For j = fromColumn To toColumn
                 'íl
                 If ws.Cells(i, j).Value <> "" Then
-                    .WriteText "    Cells(" & i & ", " & j & ") = """ & Replace(ws.Cells(i, j), vbLf, """& vbLf & """) & """", 1
+                    temp = Replace(ws.Cells(i, j), vbLf, """& vbLf & """)
+                    temp = Replace(temp, """", """""")
+                    '.WriteText "    Cells(" & i & ", " & j & ") = """ & Replace(ws.Cells(i, j), vbLf, """& vbLf & """) & """", 1
+                    .WriteText "    Cells(" & i & ", " & j & ") = """ & temp & """", 1
                 End If
                 'èëéÆ
                 If ws.Cells(i, j).NumberFormatLocal <> BASE_FORMAT Then

--- a/13_sfdc-obj-doc/setup7.bas
+++ b/13_sfdc-obj-doc/setup7.bas
@@ -3,7 +3,7 @@ Function revival0()
     ActiveWindow.DisplayGridlines = True
     ActiveWindow.Zoom = 100
     ActiveSheet.Name = "CustomObject"
-    Cells(1, 1) = "<?xml version="1.0" encoding="UTF-8"?>"
+    Cells(1, 1) = "<?xml version=""1.0"" encoding=""UTF-8""?>"
     Cells(1, 1).Font.Size = 10
     Cells(1, 1).Font.Name = "Consolas"
     Cells(1, 1).Font.Color = 128
@@ -13,7 +13,7 @@ Function revival0()
     Cells(1, 5).Font.Name = "游ゴシック"
     Cells(1, 6).Font.Name = "游ゴシック"
     Cells(1, 7).Font.Name = "游ゴシック"
-    Cells(2, 1) = "<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">"
+    Cells(2, 1) = "<CustomObject xmlns=""http://soap.sforce.com/2006/04/metadata"">"
     Cells(2, 1).Font.Size = 10
     Cells(2, 1).Font.Name = "Consolas"
     Cells(2, 1).Font.Color = 128


### PR DESCRIPTION
状態再生マクロに値中にダブルクォーテーションが含まれた場合のエスケープ処理を追加
この改修を「13_sfdc-obj-doc」の該当箇所に適用